### PR TITLE
Add ability to lock applications with a deployment

### DIFF
--- a/frontend/components/AppClosed.js
+++ b/frontend/components/AppClosed.js
@@ -1,0 +1,28 @@
+// NPM Imports
+import { Row, Col, Card } from 'antd';
+import propTypes from 'prop-types';
+import React, { Component } from 'react';
+
+class NotFound extends Component {
+  constructor() {
+    super();
+  }
+
+  render() {
+    return (
+      <Row type="flex" justify="centered">
+        <Col span={12} offset={6}>
+          <Card title={<span className="font">Application Closed</span>}>
+            <h4 className="font center">
+              We're sorry, we're no longer accepting applications for Spring
+              2018.<br />
+              <br />We hope you check back again in the Fall!
+            </h4>
+          </Card>
+        </Col>
+      </Row>
+    );
+  }
+}
+
+export default NotFound;

--- a/frontend/containers/VisitorDash/index.js
+++ b/frontend/containers/VisitorDash/index.js
@@ -8,9 +8,12 @@ import axios from 'axios';
 
 // Local Imports & Constants
 import Application from '../../components/Application';
+import AppClosed from '../../components/AppClosed';
 import * as actions from '../../ducks/auth';
 
 const { Header, Content, Footer } = Layout;
+
+const ALLOW_APPLICATIONS = true;
 
 class VisitorDash extends Component {
   constructor(props) {
@@ -62,19 +65,25 @@ class VisitorDash extends Component {
             style={{ lineHeight: '64px' }}
             onClick={this.navigate}
           >
-            <Menu.Item key="application">Application</Menu.Item>
+            {ALLOW_APPLICATIONS && (
+              <Menu.Item key="application">Application</Menu.Item>
+            )}
             <Menu.Item key="logout">Logout</Menu.Item>
           </Menu>
         </Header>
         <Content className="content-container">
           <div className="content">
-            <Application
-              register={this.props.register}
-              languages={this.state.languages}
-              web={this.state.web}
-              databases={this.state.databases}
-              deployment={this.state.deployment}
-            />
+            {ALLOW_APPLICATIONS ? (
+              <Application
+                register={this.props.register}
+                languages={this.state.languages}
+                web={this.state.web}
+                databases={this.state.databases}
+                deployment={this.state.deployment}
+              />
+            ) : (
+              <AppClosed />
+            )}
           </div>
         </Content>
         <Footer className="center">


### PR DESCRIPTION
In the future this should be a database setting so it doesn't require a deployment but this will work for now. This will not display the application form when the bool is set to `true`. 

App closed page:
![screen shot 2018-01-17 at 1 28 47 pm](https://user-images.githubusercontent.com/2718101/35059804-5e0533e0-fb8a-11e7-9f6b-25bf1e00f999.png)
